### PR TITLE
Updated the logic for the empty value for sc and nft txns

### DIFF
--- a/api/service.go
+++ b/api/service.go
@@ -506,7 +506,7 @@ func GetTransactionInfoList(limit, page int) ([]models.TransactionInfo, int64, e
 	dataQuery := `
 		SELECT transaction_id, initiator,
 			CASE WHEN owner != '' THEN owner
-			     WHEN tokens->'rbt' IS NOT NULL AND jsonb_array_length(tokens->'rbt') > 0
+			     WHEN jsonb_typeof(tokens->'rbt') = 'array' AND jsonb_array_length(tokens->'rbt') > 0
 			          THEN tokens->'rbt'->0->>'tokenId'
 			     ELSE owner
 			END AS owner,
@@ -560,7 +560,7 @@ func GetTransactionSummaryList(limit, page int) ([]models.TransactionSummary, in
 	dataQuery := `
 		SELECT transaction_id, initiator,
 			CASE WHEN owner != '' THEN owner
-			     WHEN tokens->'rbt' IS NOT NULL AND jsonb_array_length(tokens->'rbt') > 0
+			     WHEN jsonb_typeof(tokens->'rbt') = 'array' AND jsonb_array_length(tokens->'rbt') > 0
 			          THEN tokens->'rbt'->0->>'tokenId'
 			     ELSE owner
 			END AS owner,

--- a/api/service.go
+++ b/api/service.go
@@ -500,12 +500,21 @@ func GetTransactionInfoList(limit, page int) ([]models.TransactionInfo, int64, e
 	}
 
 	// 2. Fetch paginated results
+	// If owner is empty, fall back to the first RBT token ID (covers mint transactions
+	// where the node does not populate the owner field).
 	var result []models.TransactionInfo
 	dataQuery := `
-		SELECT * FROM (
-			SELECT transaction_id, initiator, owner, epoch, network, tokens, committed_tokens, quorums, memo, status, amount, created_at, updated_at FROM "TransactionInfo" WHERE amount > 0
+		SELECT transaction_id, initiator,
+			CASE WHEN owner != '' THEN owner
+			     WHEN tokens->'rbt' IS NOT NULL AND jsonb_array_length(tokens->'rbt') > 0
+			          THEN tokens->'rbt'->0->>'tokenId'
+			     ELSE owner
+			END AS owner,
+			epoch, network, tokens, committed_tokens, quorums, memo, status, amount, created_at, updated_at
+		FROM (
+			SELECT transaction_id, initiator, owner, tokens, epoch, network, committed_tokens, quorums, memo, status, amount, created_at, updated_at FROM "TransactionInfo" WHERE amount > 0
 			UNION ALL
-			SELECT transaction_id, initiator, owner, epoch, network, tokens, committed_tokens, quorums, memo, status, amount, created_at, updated_at FROM "FailedTransactionInfo" WHERE amount > 0
+			SELECT transaction_id, initiator, owner, tokens, epoch, network, committed_tokens, quorums, memo, status, amount, created_at, updated_at FROM "FailedTransactionInfo" WHERE amount > 0
 		) AS combined
 		ORDER BY created_at DESC
 		LIMIT ? OFFSET ?
@@ -545,12 +554,21 @@ func GetTransactionSummaryList(limit, page int) ([]models.TransactionSummary, in
 	}
 
 	// 2. Fetch paginated results (Summary ONLY)
+	// If owner is empty, fall back to the first RBT token ID (covers mint transactions
+	// where the node does not populate the owner field).
 	var result []models.TransactionSummary
 	dataQuery := `
-		SELECT transaction_id, initiator, owner, epoch, network, status, amount, created_at FROM (
-			SELECT transaction_id, initiator, owner, epoch, network, status, amount, created_at FROM "TransactionInfo" WHERE amount > 0
+		SELECT transaction_id, initiator,
+			CASE WHEN owner != '' THEN owner
+			     WHEN tokens->'rbt' IS NOT NULL AND jsonb_array_length(tokens->'rbt') > 0
+			          THEN tokens->'rbt'->0->>'tokenId'
+			     ELSE owner
+			END AS owner,
+			epoch, network, status, amount, created_at
+		FROM (
+			SELECT transaction_id, initiator, owner, tokens, epoch, network, status, amount, created_at FROM "TransactionInfo" WHERE amount > 0
 			UNION ALL
-			SELECT transaction_id, initiator, owner, epoch, network, status, amount, created_at FROM "FailedTransactionInfo" WHERE amount > 0
+			SELECT transaction_id, initiator, owner, tokens, epoch, network, status, amount, created_at FROM "FailedTransactionInfo" WHERE amount > 0
 		) AS combined
 		ORDER BY created_at DESC
 		LIMIT ? OFFSET ?

--- a/api/service.go
+++ b/api/service.go
@@ -698,7 +698,15 @@ func GetSCList(limit, page int) ([]models.Token, int64, error) {
 
 func GetTransactionInfo(txnID string) (models.TransactionInfo, error) {
 	var transaction models.TransactionInfo
-	if err := database.ReadDB.Table("TransactionInfo").Where("transaction_id = ?", txnID).First(&transaction).Error; err != nil {
+	query := `
+		SELECT transaction_id, initiator,
+			COALESCE(NULLIF(owner, ''), tokens->'rbt'->0->>'tokenId', tokens->'ft'->0->>'tokenId', tokens->'nft'->0->>'tokenId', tokens->'smartContract'->0->>'tokenId') AS owner,
+			epoch, network, tokens, committed_tokens, quorums, memo, status, amount, created_at, updated_at
+		FROM "TransactionInfo"
+		WHERE transaction_id = ?
+		LIMIT 1
+	`
+	if err := database.ReadDB.Raw(query, txnID).Scan(&transaction).Error; err != nil {
 		return transaction, err
 	}
 	return transaction, nil

--- a/api/service.go
+++ b/api/service.go
@@ -505,11 +505,7 @@ func GetTransactionInfoList(limit, page int) ([]models.TransactionInfo, int64, e
 	var result []models.TransactionInfo
 	dataQuery := `
 		SELECT transaction_id, initiator,
-			CASE WHEN owner != '' THEN owner
-			     WHEN jsonb_typeof(tokens->'rbt') = 'array' AND jsonb_array_length(tokens->'rbt') > 0
-			          THEN tokens->'rbt'->0->>'tokenId'
-			     ELSE owner
-			END AS owner,
+			COALESCE(NULLIF(owner, ''), tokens->'rbt'->0->>'tokenId', tokens->'ft'->0->>'tokenId', tokens->'nft'->0->>'tokenId', tokens->'smartContract'->0->>'tokenId') AS owner,
 			epoch, network, tokens, committed_tokens, quorums, memo, status, amount, created_at, updated_at
 		FROM (
 			SELECT transaction_id, initiator, owner, tokens, epoch, network, committed_tokens, quorums, memo, status, amount, created_at, updated_at FROM "TransactionInfo" WHERE amount > 0
@@ -559,11 +555,7 @@ func GetTransactionSummaryList(limit, page int) ([]models.TransactionSummary, in
 	var result []models.TransactionSummary
 	dataQuery := `
 		SELECT transaction_id, initiator,
-			CASE WHEN owner != '' THEN owner
-			     WHEN jsonb_typeof(tokens->'rbt') = 'array' AND jsonb_array_length(tokens->'rbt') > 0
-			          THEN tokens->'rbt'->0->>'tokenId'
-			     ELSE owner
-			END AS owner,
+			COALESCE(NULLIF(owner, ''), tokens->'rbt'->0->>'tokenId', tokens->'ft'->0->>'tokenId', tokens->'nft'->0->>'tokenId', tokens->'smartContract'->0->>'tokenId') AS owner,
 			epoch, network, status, amount, created_at
 		FROM (
 			SELECT transaction_id, initiator, owner, tokens, epoch, network, status, amount, created_at FROM "TransactionInfo" WHERE amount > 0

--- a/database/operations/transaction_operations.go
+++ b/database/operations/transaction_operations.go
@@ -67,11 +67,17 @@ func SaveTransactionDetails(db *gorm.DB, txnID string, info *model.TransactionIn
 		}
 	}
 
+	// For smart contract transactions, owner = the SC token ID (not the receiver DID).
+	owner := info.Owner
+	if info.Tokens != nil && len(info.Tokens.SmartContract) > 0 {
+		owner = info.Tokens.SmartContract[0].TokenID
+	}
+
 	if status {
 		details := &models.TransactionInfo{
 			TransactionID:   txnID,
 			Initiator:       info.Initiator,
-			Owner:           info.Owner,
+			Owner:           owner,
 			Epoch:           info.Epoch,
 			Network:         info.Network,
 			Tokens:          tokensJSON,
@@ -86,7 +92,7 @@ func SaveTransactionDetails(db *gorm.DB, txnID string, info *model.TransactionIn
 		details := &models.FailedTransactionInfo{
 			TransactionID:   txnID,
 			Initiator:       info.Initiator,
-			Owner:           info.Owner,
+			Owner:           owner,
 			Epoch:           info.Epoch,
 			Network:         info.Network,
 			Tokens:          tokensJSON,

--- a/database/operations/transaction_operations.go
+++ b/database/operations/transaction_operations.go
@@ -67,24 +67,11 @@ func SaveTransactionDetails(db *gorm.DB, txnID string, info *model.TransactionIn
 		}
 	}
 
-	// Derive owner based on transaction type:
-	// - SC transactions:        owner = SC token ID
-	// - RBT mint/split (no owner set by node): owner = token's DID field
-	// - All other cases:        owner = info.Owner as received
-	owner := info.Owner
-	if info.Tokens != nil {
-		if len(info.Tokens.SmartContract) > 0 {
-			owner = info.Tokens.SmartContract[0].TokenID
-		} else if owner == "" && len(info.Tokens.RBT) > 0 {
-			owner = info.Tokens.RBT[0].DID
-		}
-	}
-
 	if status {
 		details := &models.TransactionInfo{
 			TransactionID:   txnID,
 			Initiator:       info.Initiator,
-			Owner:           owner,
+			Owner:           info.Owner,
 			Epoch:           info.Epoch,
 			Network:         info.Network,
 			Tokens:          tokensJSON,
@@ -99,7 +86,7 @@ func SaveTransactionDetails(db *gorm.DB, txnID string, info *model.TransactionIn
 		details := &models.FailedTransactionInfo{
 			TransactionID:   txnID,
 			Initiator:       info.Initiator,
-			Owner:           owner,
+			Owner:           info.Owner,
 			Epoch:           info.Epoch,
 			Network:         info.Network,
 			Tokens:          tokensJSON,

--- a/database/operations/transaction_operations.go
+++ b/database/operations/transaction_operations.go
@@ -67,10 +67,17 @@ func SaveTransactionDetails(db *gorm.DB, txnID string, info *model.TransactionIn
 		}
 	}
 
-	// For smart contract transactions, owner = the SC token ID (not the receiver DID).
+	// Derive owner based on transaction type:
+	// - SC transactions:        owner = SC token ID
+	// - RBT mint/split (no owner set by node): owner = token's DID field
+	// - All other cases:        owner = info.Owner as received
 	owner := info.Owner
-	if info.Tokens != nil && len(info.Tokens.SmartContract) > 0 {
-		owner = info.Tokens.SmartContract[0].TokenID
+	if info.Tokens != nil {
+		if len(info.Tokens.SmartContract) > 0 {
+			owner = info.Tokens.SmartContract[0].TokenID
+		} else if owner == "" && len(info.Tokens.RBT) > 0 {
+			owner = info.Tokens.RBT[0].DID
+		}
 	}
 
 	if status {


### PR DESCRIPTION
For the api endpoint : /get-latest-transactions
Added the logic if the owner field is empty then use the tokenId in owner key for the response . 
Owner was null for the smart contract and nft txns , which is updated now 